### PR TITLE
Add configuration options to abstract away DB and Args

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -6,7 +6,7 @@ verify_ssl = true
 [dev-packages]
 
 [packages]
-sqlsorcery = {extras = ["mssql"],version = "*"}
+sqlsorcery = {extras = ["mssql", "postgres"],version = "*"}
 google-api-python-client = "*"
 google-auth-httplib2 = "*"
 google-auth-oauthlib = "*"

--- a/README.md
+++ b/README.md
@@ -30,11 +30,24 @@ It will filter student reports to that specific organization.
 
 ```
 # Database variables
+DB_TYPE=The type of database you are using. Current options: mssql, postgres, sqlite
 DB_SERVER=
 DB=
 DB_USER=
 DB_PWD=
 DB_SCHEMA=
+
+# OPTIONAL: Data Pulls To Enable. Set to "YES" to include that pull.
+# These can be left out in favor of command line arguments.
+PULL_USAGE=
+PULL_COURSES=
+PULL_TOPICS=
+PULL_COURSEWORK=
+PULL_STUDENTS=
+PULL_TEACHERS=
+PULL_GUARDIANS=
+PULL_SUBMISSIONS=
+PULL_GUARDIAN_INVITES=
 
 # Google API variables
 STUDENT_ORG_UNIT=name of the student org unit
@@ -86,6 +99,20 @@ Run the job using a database on localhost
 ```
 docker run --rm -it --network host google_classroom
 ```
+
+Optional flags will include different types of pulls (can also be done via env variables):
+
+- `--usage`
+- `--courses`
+- `--topics`
+- `--coursework`
+- `--students`
+- `--teachers`
+- `--guardians`
+- `--submissions`
+- `--invites`
+
+Use the flag `--debug` to turn on debug logging.
 
 ### Yearly maintenance
 

--- a/config.py
+++ b/config.py
@@ -1,0 +1,68 @@
+# Configuration file for types of configurations.
+
+import os
+import argparse
+from sqlsorcery import MSSQL, PostgreSQL, SQLite
+
+
+def get_args():
+    parser = argparse.ArgumentParser(description="Pick which ones")
+    parser.add_argument("--usage", help="Import student usage data", action="store_true")
+    parser.add_argument("--courses", help="Import course lists", action="store_true")
+    parser.add_argument("--topics", help="Import course topics", action="store_true")
+    parser.add_argument("--coursework", help="Import course assignments", action="store_true")
+    parser.add_argument("--students", help="Import student rosters", action="store_true")
+    parser.add_argument("--teachers", help="Import teacher rosters", action="store_true")
+    parser.add_argument("--guardians", help="Import student guardians", action="store_true")
+    parser.add_argument(
+        "--submissions", help="Import student coursework submissions", action="store_true"
+    )
+    parser.add_argument("--invites", help="Import guardian invite statuses", action="store_true")
+    parser.add_argument(
+        "--debug", help="Set logging level for troubleshooting", action="store_true"
+    )
+    return parser.parse_args()
+
+
+class Config(object):
+    """Base configuration object"""
+    args = get_args()
+    STUDENT_ORG_UNIT = os.getenv("STUDENT_ORG_UNIT")
+    SCHOOL_YEAR_START = os.getenv("SCHOOL_YEAR_START")
+    DB_TYPE = os.getenv("DB_TYPE")
+    DEBUG = args.debug
+    PULL_USAGE = os.getenv("PULL_USAGE") == "YES" or args.usage
+    PULL_COURSES = os.getenv("PULL_COURSES") == "YES" or args.courses
+    PULL_TOPICS = os.getenv("PULL_TOPICS") == "YES" or args.topics
+    PULL_COURSEWORK = os.getenv("PULL_COURSEWORK") == "YES" or args.coursework
+    PULL_STUDENTS = os.getenv("PULL_STUDENTS") == "YES" or args.students
+    PULL_TEACHERS = os.getenv("PULL_TEACHERS") == "YES" or args.teachers
+    PULL_GUARDIANS = os.getenv("PULL_GUARDIANS") == "YES" or args.guardians
+    PULL_SUBMISSIONS = os.getenv("PULL_SUBMISSIONS") == "YES" or args.submissions
+    PULL_GUARDIAN_INVITES = os.getenv("PULL_GUARDIAN_INVITES") == "YES" or args.invites
+
+
+class Test_Config(Config):
+    DB_TYPE = "sqlite"
+    DEBUG = False
+    PULL_USAGE = True
+    PULL_COURSES = True
+    PULL_TOPICS = True
+    PULL_COURSEWORK = True
+    PULL_STUDENTS = True
+    PULL_TEACHERS = True
+    PULL_GUARDIANS = True
+    PULL_SUBMISSIONS = True
+    PULL_GUARDIAN_INVITES = True
+
+
+def db_generator(config):
+    db_type = config.DB_TYPE
+    if db_type == "mssql":
+        return MSSQL()
+    elif db_type == "postgres":
+        return PostgreSQL()
+    elif db_type == "sqlite":
+        return SQLite()
+    else:
+        raise Exception()


### PR DESCRIPTION
Depends on `cleanup_api_calls`

Adds a configuration file that helps take care of selecting the DB, as well as taking in args so that the Dockerfile doesn't need to be edited every time you want to run something different.

NOTE: There was already a `config.py` file in the repo, but I couldn't find where it was used anywhere. I just deleted it entirely, but we can rename it to something else if someone is planning to use it.

I originally had the DB hang off the config object itself, but when that happens the initial import creates all of the DBs and causes errors. Still thinking if there's a nice way to encapsulate the DB generator so that `main.py` doesn't need to know about it at all.

Fixes #16, #20 