### PR TITLE
Fixes Org Unit Pull

### DIFF
--- a/api.py
+++ b/api.py
@@ -126,7 +126,7 @@ class EndPoint:
                     #  Process the records and write them to a database.
                     df = self._process_and_filter_records(records)
                     self._write_to_db(sql, df)
-                    all_data = all_data.append(df)
+                    all_data = all_data.append(df) if not all_data.empty else df
         return all_data
 
 


### PR DESCRIPTION
Fixes a bug where the org unit id wasn't being properly returned because the dataframe append was pivoting the result data.

This is a quick fix, but perhaps not the most elegant. An alternative solution may be ensuring that the OrgUnit filtering creates a format where the append functionality works as intended, but this change should at least unbreak the library so that it can continue to be used.