### PR TITLE
Get All Student Usage From Last Updated Until Today

### DIFF
--- a/api.py
+++ b/api.py
@@ -192,7 +192,7 @@ class StudentUsage(EndPoint):
 
     def remove_dates_after(self, sql, date):
         """Removes the given date and any after from the database."""
-        logging.debug(f"Deleting usage during and after {date} from {self.table_name}.")
+        logging.info(f"Deleting usage during and after {date} from {self.table_name}.")
         table = sql.table(self.table_name)
         query = table.delete().where(table.c.AsOfDate >= date)
         sql.engine.execute(query)

--- a/api.py
+++ b/api.py
@@ -6,6 +6,7 @@ from googleapiclient.http import HttpError
 import pandas as pd
 from tenacity import retry, stop_after_attempt, wait_exponential
 from sqlalchemy.schema import DropTable
+from sqlalchemy.exc import NoSuchTableError
 from timer import elapsed
 
 
@@ -81,9 +82,8 @@ class EndPoint:
         try:
             table = sql.table(self.table_name)
             sql.engine.execute(DropTable(table))
-        except:
-            # Errors when the table doesn't exist.
-            pass
+        except NoSuchTableError as error:
+            logging.debug(f"{error}: Attempted deletion, but no table exists.")
 
     @retry(
         stop=stop_after_attempt(5), wait=wait_exponential(multiplier=1, min=4, max=10)


### PR DESCRIPTION
Changes the student usage pull so that it pulls from the last available today until today. This means that the data becomes idempotent (it can be run as frequently as you want without duplicating data) as well as not needing to be run every day to capture data.
 Functionality includes:
 - Deletes the last day in the database when available, because it may not be complete data. An alternative solution here would be to keep track of whether data is partial, but that would require parsing warnings from the JSON return and could be less reliable.
 - If no data is available, it will start from the start of the school year. For fresh starts, that means it might take a few minutes to run. If we think there's a need, this date could also be a separate configuration date instead. This shouldn't have an effect on databases with data already in it.
 - Adds some more logging and transparency around the dates it is pulling, and adds functionality for other endpoints that need to be called by day.

Which I do the batch requests, I will try to batch dates as well as courses.

@dchess Can you test this locally to make sure it works for you before any merges? 

Fixes #29 