### PR TITLE
Add Initial Testing

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,4 +11,4 @@ RUN pip install pipenv
 COPY Pipfile .
 RUN pipenv install --skip-lock
 COPY ./ .
-ENTRYPOINT ["pipenv", "run", "python", "main.py"]
+ENTRYPOINT ["./boot.sh"]

--- a/Pipfile
+++ b/Pipfile
@@ -11,6 +11,7 @@ google-api-python-client = "*"
 google-auth-httplib2 = "*"
 google-auth-oauthlib = "*"
 tenacity = "*"
+pytest = "*"
 
 [requires]
 python_version = "3.7"

--- a/README.md
+++ b/README.md
@@ -124,6 +124,16 @@ Optional flags will include different types of pulls (can also be done via env v
 
 Use the flag `--debug` to turn on debug logging.
 
+### Running Tests
+
+Tests are located in tests,py, and can be run with the following command:
+
+```
+pipenv run py.test tests.py
+```
+
+When making changes, please run tests to make sure you have not broken anything.
+
 ### Yearly maintenance
 
 1. Confirm the org unit ID (used to get Student Usage) in the .env.

--- a/README.md
+++ b/README.md
@@ -126,10 +126,19 @@ Use the flag `--debug` to turn on debug logging.
 
 ### Running Tests
 
-Tests are located in tests,py, and can be run with the following command:
+Tests are located in tests,py, and can be run with either of the following commands:
+
+Locally:
 
 ```
-pipenv run py.test tests.py
+pipenv run py.test -s -v tests.py
+```
+
+On Docker:
+
+```
+docker build -t google_classroom .
+docker run --rm -it google_classroom --test
 ```
 
 When making changes, please run tests to make sure you have not broken anything.

--- a/boot.sh
+++ b/boot.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+if [[ $1 = "--test" ]]
+then
+    echo "Running tests."
+    exec pipenv run py.test -s -v tests.py
+else
+    echo "Starting loading script."
+    exec pipenv run python main.py $@
+fi

--- a/config.py
+++ b/config.py
@@ -35,7 +35,8 @@ def get_args():
     parser.add_argument(
         "--debug", help="Set logging level for troubleshooting", action="store_true"
     )
-    return parser.parse_args()
+    args, _ = parser.parse_known_args()
+    return args
 
 
 class Config(object):
@@ -63,7 +64,7 @@ class Config(object):
     DISABLE_MAILER = os.getenv("DISABLE_MAILER") == "YES"
 
 
-class Test_Config(Config):
+class TestConfig(Config):
     DB_TYPE = "sqlite"
     DEBUG = False
     PULL_USAGE = True
@@ -76,6 +77,9 @@ class Test_Config(Config):
     PULL_SUBMISSIONS = True
     PULL_GUARDIAN_INVITES = True
     DISABLE_MAILER = True
+    SCHOOL_YEAR_START = "2020-01-01"
+    SQLITE_FILE = "tests.db"
+    STUDENT_ORG_UNIT = "Test Organization 2"
 
 
 def db_generator(config):
@@ -85,6 +89,6 @@ def db_generator(config):
     elif db_type == "postgres":
         return PostgreSQL()
     elif db_type == "sqlite":
-        return SQLite()
+        return SQLite(path=config.SQLITE_FILE)
     else:
         raise Exception()

--- a/main.py
+++ b/main.py
@@ -93,15 +93,21 @@ def main(config):
         ou_id = None if result.empty else result.iloc[0]
 
         # Then get usage
-        # Clear out the last day's worth of data, because it may only be partially complete.
-        # Then load data on all dates from that day until today.
+        # Clear out the last day's worth of data, because it may only be partially
+        # complete. Then load data on all dates from that day until today.
         usage = StudentUsage(admin_reports_service, ou_id)
         last_date = usage.get_last_date(sql)
         if last_date:
             usage.remove_dates_after(sql, last_date)
-        start_date = last_date or datetime.strptime(config.SCHOOL_YEAR_START, "%Y-%m-%d")
-        date_range = pd.date_range(start=start_date, end=datetime.today()).strftime("%Y-%m-%d")
-        usage.get_and_write_to_db(sql, dates=date_range, overwrite=False, debug=config.DEBUG)
+        start_date = last_date or datetime.strptime(
+            config.SCHOOL_YEAR_START, "%Y-%m-%d"
+        )
+        date_range = pd.date_range(start=start_date, end=datetime.today()).strftime(
+            "%Y-%m-%d"
+        )
+        usage.get_and_write_to_db(
+            sql, dates=date_range, overwrite=False, debug=config.DEBUG
+        )
 
     # Get guardians
     if config.PULL_GUARDIANS:

--- a/test_responses.py
+++ b/test_responses.py
@@ -1,0 +1,341 @@
+import pandas as pd
+
+ORG_UNIT_SOLUTION = pd.DataFrame({"orgUnitId": ["id:987654"]})
+ORG_UNIT_RESPONSE = {
+    "organizationUnits": [
+        {
+            "kind": "admin#directory#orgUnit",
+            "etag": '"abcdef"',
+            "name": "Test Organization",
+            "description": "Description",
+            "orgUnitPath": "/TestOrg",
+            "orgUnitId": "id:123456",
+            "parentOrgUnitPath": "/",
+            "parentOrgUnitId": "id:234567",
+        },
+        {
+            "kind": "admin#directory#orgUnit",
+            "etag": '"qwerty"',
+            "name": "Test Organization 2",
+            "description": "Description 2",
+            "orgUnitPath": "/TestOrg2",
+            "orgUnitId": "id:987654",
+            "parentOrgUnitPath": "/",
+            "parentOrgUnitId": "id:876543",
+        },
+    ],
+}
+
+GUARDIAN_SOLUTION = pd.DataFrame(
+    {
+        "studentId": ["12345", "33333"],
+        "guardianId": ["23456", "44444"],
+        "invitedEmailAddress": ["anotherName@email.com", "aname2@email.com"],
+    }
+)
+GUARDIAN_RESPONSE = {
+    "guardians": [
+        {
+            "studentId": "12345",
+            "guardianId": "23456",
+            "guardianProfile": {
+                "id": "999888777",
+                "name": {
+                    "givenName": "First",
+                    "familyName": "Last",
+                    "fullName": "First Last",
+                },
+                "emailAddress": "name@email.com",
+            },
+            "invitedEmailAddress": "anotherName@email.com",
+        },
+        {
+            "studentId": "33333",
+            "guardianId": "44444",
+            "guardianProfile": {
+                "id": "1111111333",
+                "name": {
+                    "givenName": "Another",
+                    "familyName": "Name",
+                    "fullName": "Another Name",
+                },
+                "emailAddress": "aname@email.com",
+            },
+            "invitedEmailAddress": "aname2@email.com",
+        },
+    ]
+}
+
+GUARDIAN_INVITE_SOLUTION = pd.DataFrame(
+    {
+        "studentId": ["12345", "333"],
+        "invitationId": ["1", "2"],
+        "invitedEmailAddress": ["name@email.com", "another_name@email.com"],
+        "state": ["COMPLETE", "COMPLETE"],
+        "creationTime": [
+            pd.to_datetime("2020-04-05 19:42:29.966"),
+            pd.to_datetime("2020-05-05 19:42:29.966"),
+        ],
+    }
+)
+GUARDIAN_INVITE_RESPONSE = {
+    "guardianInvitations": [
+        {
+            "studentId": "12345",
+            "invitationId": "1",
+            "invitedEmailAddress": "name@email.com",
+            "state": "COMPLETE",
+            "creationTime": "2020-04-05T19:42:29.966Z",
+        },
+        {
+            "studentId": "333",
+            "invitationId": "2",
+            "invitedEmailAddress": "another_name@email.com",
+            "state": "COMPLETE",
+            "creationTime": "2020-05-05T19:42:29.966Z",
+        },
+    ]
+}
+
+COURSE_SOLUTION = pd.DataFrame(
+    {
+        "id": ["12345", "23456"],
+        "name": ["Science Class", "Math Class"],
+        "courseGroupEmail": ["science@class.com", "math@class.com"],
+        "courseState": ["ACTIVE", "ACTIVE"],
+        "creationTime": [
+            pd.to_datetime("2020-04-05 19:41:15.292"),
+            pd.to_datetime("2020-04-01 17:44:34.899"),
+        ],
+        "description": ["Class description 1", "Class description 2"],
+        "descriptionHeading": ["Science Class", "Math Class"],
+        "enrollmentCode": ["abcdefg", "ghijklmnop"],
+        "guardiansEnabled": [True, True],
+        "ownerId": ["123", "234"],
+        "room": ["Room1", "Room2"],
+        "section": ["1", "2"],
+        "teacherGroupEmail": ["science_teachers@class.com", "math_teachers@class.com"],
+        "updateTime": [
+            pd.to_datetime("2020-04-05 19:41:14.305"),
+            pd.to_datetime("2020-04-01 20:54:08.531"),
+        ],
+    }
+)
+COURSE_RESPONSE = {
+    "courses": [
+        {
+            "id": "12345",
+            "name": "Science Class",
+            "courseGroupEmail": "science@class.com",
+            "courseState": "ACTIVE",
+            "creationTime": "2020-04-05T19:41:15.292Z",
+            "description": "Class description 1",
+            "descriptionHeading": "Science Class",
+            "enrollmentCode": "abcdefg",
+            "guardiansEnabled": True,
+            "ownerId": "123",
+            "room": "Room1",
+            "section": "1",
+            "teacherGroupEmail": "science_teachers@class.com",
+            "updateTime": "2020-04-05T19:41:14.305Z",
+        },
+        {
+            "id": "23456",
+            "name": "Math Class",
+            "courseGroupEmail": "math@class.com",
+            "courseState": "ACTIVE",
+            "creationTime": "2020-04-01T17:44:34.899Z",
+            "description": "Class description 2",
+            "descriptionHeading": "Math Class",
+            "enrollmentCode": "ghijklmnop",
+            "guardiansEnabled": True,
+            "ownerId": "234",
+            "room": "Room2",
+            "section": "2",
+            "teacherGroupEmail": "math_teachers@class.com",
+            "updateTime": "2020-04-01T20:54:08.531Z",
+        },
+    ]
+}
+
+TOPIC_SOLUTION = pd.DataFrame(
+    {
+        "courseId": ["1234", "5678"],
+        "topicId": ["1235", "1234"],
+        "name": ["Chemistry", "Biology"],
+        "updateTime": [
+            pd.to_datetime("2020-04-05 22:41:55.871"),
+            pd.to_datetime("2020-04-05 22:41:49.187"),
+        ],
+    }
+)
+TOPIC_RESPONSE = {
+    "topic": [
+        {
+            "courseId": "1234",
+            "topicId": "1235",
+            "name": "Chemistry",
+            "updateTime": "2020-04-05T22:41:55.871Z",
+        },
+        {
+            "courseId": "5678",
+            "topicId": "1234",
+            "name": "Biology",
+            "updateTime": "2020-04-05T22:41:49.187Z",
+        },
+    ]
+}
+
+STUDENT_SOLUTION = pd.DataFrame(
+    {
+        "courseId": ["123", "123"],
+        "userId": ["1", "2"],
+        "profile.name.fullName": ["Test User", "Another User"],
+        "profile.emailAddress": ["test_user@email.com", "another_user@email.com"],
+    }
+)
+STUDENT_RESPONSE = {
+    "students": [
+        {
+            "courseId": "123",
+            "userId": "1",
+            "profile": {
+                "id": "222",
+                "name": {
+                    "givenName": "Test",
+                    "familyName": "User",
+                    "fullName": "Test User",
+                },
+                "emailAddress": "test_user@email.com",
+            },
+        },
+        {
+            "courseId": "123",
+            "userId": "2",
+            "profile": {
+                "id": "333",
+                "name": {
+                    "givenName": "Another",
+                    "familyName": "User",
+                    "fullName": "Another User",
+                },
+                "emailAddress": "another_user@email.com",
+                "permissions": [{"permission": "CREATE_COURSE"}],
+            },
+        },
+    ]
+}
+
+TEACHER_SOLUTION = pd.DataFrame(
+    {
+        "courseId": ["111", "333", "444"],
+        "userId": ["555", "321", "555"],
+        "profile.name.fullName": ["Boss Lady", "Mr. Teacher", "Mrs. Teacher"],
+        "profile.emailAddress": [
+            "boss_lady@email.com",
+            "mr_teacher@email.com",
+            "mrs_teacher@email.com",
+        ],
+    }
+)
+TEACHER_RESPONSE = {
+    "teachers": [
+        {
+            "courseId": "111",
+            "userId": "555",
+            "profile": {
+                "id": "987",
+                "name": {
+                    "givenName": "Boss",
+                    "familyName": "Lady",
+                    "fullName": "Boss Lady",
+                },
+                "emailAddress": "boss_lady@email.com",
+                "permissions": [{"permission": "CREATE_COURSE"}],
+            },
+        },
+        {
+            "courseId": "333",
+            "userId": "321",
+            "profile": {
+                "id": "543",
+                "name": {
+                    "givenName": "Mr.",
+                    "familyName": "Teacher",
+                    "fullName": "Mr. Teacher",
+                },
+                "emailAddress": "mr_teacher@email.com",
+                "permissions": [{"permission": "CREATE_COURSE"}],
+            },
+        },
+        {
+            "courseId": "444",
+            "userId": "555",
+            "profile": {
+                "id": "789",
+                "name": {
+                    "givenName": "Mrs.",
+                    "familyName": "Teacher",
+                    "fullName": "Mrs. Teacher",
+                },
+                "emailAddress": "mrs_teacher@email.com",
+                "permissions": [{"permission": "CREATE_COURSE"}],
+            },
+        },
+    ]
+}
+
+
+class FakeRequest:
+    def __init__(self, result, *args, **kwargs):
+        self.result = result
+        self.args = args
+        self.kwargs = kwargs
+
+    def execute(self):
+        if "courseId" in self.kwargs:
+            course_id = self.kwargs["courseId"]
+            if course_id is not None:
+                # If a course_id is provided, this splits the results into two courses.
+                key = list(self.result.keys())[0]
+                if course_id == 0:
+                    return {key: self.result[key][0]}
+                else:
+                    return {key: self.result[key][1:]}
+        return self.result
+
+
+class FakeEndpoint:
+    def __init__(self, result):
+        self.result = result
+
+    def list(self, *args, **kwargs):
+        return FakeRequest(self.result, *args, **kwargs)
+
+
+class FakeService:
+    class Courses(FakeEndpoint):
+        def topics(self):
+            return FakeEndpoint(TOPIC_RESPONSE)
+
+        def students(self):
+            return FakeEndpoint(STUDENT_RESPONSE)
+
+        def teachers(self):
+            return FakeEndpoint(TEACHER_RESPONSE)
+
+    def courses(self):
+        return self.Courses(COURSE_RESPONSE)
+
+    def orgunits(self):
+        return FakeEndpoint(ORG_UNIT_RESPONSE)
+
+    class UserProfiles:
+        def guardians(self):
+            return FakeEndpoint(GUARDIAN_RESPONSE)
+
+        def guardianInvitations(self):
+            return FakeEndpoint(GUARDIAN_INVITE_RESPONSE)
+
+    def userProfiles(self):
+        return self.UserProfiles()

--- a/tests.py
+++ b/tests.py
@@ -1,0 +1,75 @@
+from config import TestConfig, db_generator
+from api import (
+    Courses,
+    OrgUnits,
+    Guardians,
+    GuardianInvites,
+    Topics,
+    Students,
+    Teachers,
+)
+import os
+import pandas as pd
+from test_responses import (
+    FakeService,
+    ORG_UNIT_SOLUTION,
+    GUARDIAN_SOLUTION,
+    GUARDIAN_INVITE_SOLUTION,
+    COURSE_SOLUTION,
+    TOPIC_SOLUTION,
+    STUDENT_SOLUTION,
+    TEACHER_SOLUTION,
+)
+
+# TODO: Add tests for Coursework and Submissions.
+
+
+class TestEndToEnd:
+    def setup(self):
+        self.config = TestConfig
+        self.sql = db_generator(self.config)
+        self.service = FakeService()
+
+    def teardown(self):
+        if os.path.exists(self.config.SQLITE_FILE):
+            os.remove(self.config.SQLITE_FILE)
+
+    def test_get_org_units(self):
+        self.generic_get_test(
+            OrgUnits(self.service, self.config.STUDENT_ORG_UNIT), ORG_UNIT_SOLUTION,
+        )
+
+    def test_get_guardians(self):
+        self.generic_get_test(Guardians(self.service), GUARDIAN_SOLUTION)
+
+    def test_get_guardian_invites(self):
+        self.generic_get_test(GuardianInvites(self.service), GUARDIAN_INVITE_SOLUTION)
+
+    def test_get_courses(self):
+        self.generic_get_test(
+            Courses(self.service, self.config.SCHOOL_YEAR_START), COURSE_SOLUTION,
+        )
+
+    def test_get_topics(self):
+        self.generic_get_test(
+            Topics(self.service), TOPIC_SOLUTION, course_ids=[0, 1],
+        )
+
+    def test_get_students(self):
+        self.generic_get_test(
+            Students(self.service), STUDENT_SOLUTION, course_ids=[0, 1],
+        )
+
+    def test_get_teachers(self):
+        self.generic_get_test(
+            Teachers(self.service), TEACHER_SOLUTION, course_ids=[0, 1],
+        )
+
+    def generic_get_test(self, endpoint, solution, course_ids=[None]):
+        endpoint.get_and_write_to_db(
+            self.sql, debug=self.config.DEBUG, course_ids=course_ids
+        )
+        result = pd.read_sql_table(
+            endpoint.table_name, con=self.sql.engine, schema=self.sql.schema
+        )
+        assert result.equals(solution)


### PR DESCRIPTION
Depends on #33 
Fixes #14

This branch adds some basic testing using pytest. A few notes on changes:
 - I went with creating a mock object rather than spoofing API calls since it felt more straightforward and are generally not concerned with the behavior of Google's library.
 - There are many, many things that have not been tested. We can add to this over time, but this should give us enough safety to feel more comfortable with major changes like batch / parallel work.
 - There are some "hacks" in the testing. Notably, I use the response and the endpoint.columns lists to check whether the database has been written to correctly. I also split the calls by course_id very arbitrarily, and only allow two class_ids right now. Ideally we can eventually make this more explicit, but this was done for expediency.
 - The change to the parser was done because it was picking up the args when running pytest. I'm not yet sure how to separate the args into the production-only environment, but will try some more things later. This was the quickest solution, just ignoring undefined args.
 - Eventually we should use Faker for response data, but I wanted to test first with explicit responses.
 - There is some random linting since I am now using `black`, which has a different line width limit.