### PR TITLE
Adds Batch Calling

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,10 @@ PULL_GUARDIANS=
 PULL_SUBMISSIONS=
 PULL_GUARDIAN_INVITES=
 
+# Batch parameters. Can be configured and changed to optimize performance.
+BATCH_SIZE=The number of dates or courses to batch at a time. MAX: 1000.
+PAGE_SIZE=The number of items to page at once.
+
 # Email notification variables
 # OPTIONAL: Set DISABLE_MAILER to "YES" if you do not want email notifications to be sent.
 DISABLE_MAILER=

--- a/README.md
+++ b/README.md
@@ -49,8 +49,19 @@ PULL_GUARDIANS=
 PULL_SUBMISSIONS=
 PULL_GUARDIAN_INVITES=
 
-# Batch parameters. Can be configured and changed to optimize performance.
-BATCH_SIZE=The number of dates or courses to batch at a time. MAX: 1000.
+# (Optional) Batch parameters. Can be configured and changed to optimize performance.
+# *_BATCH_SIZE is the number of dates or courses to batch at a time. MAX: 1000
+# Lower batch sizes are useful for high volume or slow endpoints to avoid timeouts.
+ORG_UNIT_BATCH_SIZE=
+USAGE_BATCH_SIZE=
+COURSES_BATCH_SIZE=
+TOPICS_BATCH_SIZE=
+COURSEWORK_BATCH_SIZE=
+STUDENTS_BATCH_SIZE=
+TEACHERS_BATCH_SIZE=
+GUARDIANS_BATCH_SIZE=
+SUBMISSIONS_BATCH_SIZE=
+GUARDIAN_INVITES_BATCH_SIZE=
 PAGE_SIZE=The number of items to page at once.
 
 # Email notification variables

--- a/api.py
+++ b/api.py
@@ -163,10 +163,9 @@ class EndPoint:
                 all_data = df if all_data is None else all_data.append(df)
 
         request_list = list(itertools.product(course_ids, dates))
-        batch_size = int(self.config.BATCH_SIZE)
-        number_batches = math.ceil(len(request_list) / batch_size)
-        for batch_num, i in enumerate(range(0, len(request_list), batch_size)):
-            request_batch = request_list[i : i + batch_size]
+        number_batches = math.ceil(len(request_list) / self.batch_size)
+        for batch_num, i in enumerate(range(0, len(request_list), self.batch_size)):
+            request_batch = request_list[i : i + self.batch_size]
             logging.info(
                 f"{self.classname()}: making {len(request_batch)} requests, batch {batch_num+1}/{number_batches}"
             )
@@ -194,6 +193,7 @@ class OrgUnits(EndPoint):
         self.date_columns = []
         self.columns = ["name", "description", "orgUnitPath", "orgUnitId"]
         self.request_key = "organizationUnits"
+        self.batch_size = config.ORG_UNIT_BATCH_SIZE
 
     def request_data(self, course_id=None, date=None, next_page_token=None):
         """Request org unit that matches the given path"""
@@ -212,6 +212,7 @@ class StudentUsage(EndPoint):
         self.columns = ["Email", "AsOfDate", "LastUsedTime"]
         self.org_unit_id = org_unit_id
         self.request_key = "usageReports"
+        self.batch_size = config.USAGE_BATCH_SIZE
 
     def get_last_date(self):
         """Gets the last available date of data in the database."""
@@ -269,6 +270,7 @@ class Guardians(EndPoint):
         self.date_columns = []
         self.columns = ["studentId", "guardianId", "invitedEmailAddress"]
         self.request_key = "guardians"
+        self.batch_size = config.GUARDIANS_BATCH_SIZE
 
     def request_data(self, course_id=None, date=None, next_page_token=None):
         """Request all guardians."""
@@ -295,6 +297,7 @@ class GuardianInvites(EndPoint):
             "creationTime",
         ]
         self.request_key = "guardianInvitations"
+        self.batch_size = config.GUARDIAN_INVITES_BATCH_SIZE
 
     def request_data(self, course_id=None, date=None, next_page_token=None):
         """Request all pending and complete guardian invites."""
@@ -331,13 +334,14 @@ class Courses(EndPoint):
             "updateTime",
         ]
         self.request_key = "courses"
+        self.batch_size = config.COURSES_BATCH_SIZE
 
     def get_course_ids(self):
         try:
             courses = pd.read_sql_table(
                 self.table_name, con=self.sql.engine, schema=self.sql.schema
             )
-            return courses.id.unique()
+            return sorted(courses.id.unique())
         except InvalidRequestError as error:
             logging.debug(error)
             return None
@@ -360,6 +364,7 @@ class Topics(EndPoint):
         self.date_columns = ["updateTime"]
         self.columns = ["courseId", "topicId", "name", "updateTime"]
         self.request_key = "topic"
+        self.batch_size = config.TOPICS_BATCH_SIZE
 
     def request_data(self, course_id=None, date=None, next_page_token=None):
         """Request all topics for this course."""
@@ -384,6 +389,7 @@ class Teachers(EndPoint):
             "profile.emailAddress",
         ]
         self.request_key = "teachers"
+        self.batch_size = config.TEACHERS_BATCH_SIZE
 
     def request_data(self, course_id=None, date=None, next_page_token=None):
         """Request all teachers for this course."""
@@ -408,6 +414,7 @@ class Students(EndPoint):
             "profile.emailAddress",
         ]
         self.request_key = "students"
+        self.batch_size = config.STUDENTS_BATCH_SIZE
 
     def request_data(self, course_id=None, date=None, next_page_token=None):
         """Request all students for this course."""
@@ -448,6 +455,7 @@ class CourseWork(EndPoint):
             "topicId",
         ]
         self.request_key = "courseWork"
+        self.batch_size = config.COURSEWORK_BATCH_SIZE
 
     def request_data(self, course_id=None, date=None, next_page_token=None):
         """Request all coursework for this course."""
@@ -496,6 +504,7 @@ class StudentSubmissions(EndPoint):
             "assignedGraderId",
         ]
         self.request_key = "studentSubmissions"
+        self.batch_size = config.SUBMISSIONS_BATCH_SIZE
 
     def request_data(self, course_id=None, date=None, next_page_token=None):
         """Request all student submissions for this course."""

--- a/config.py
+++ b/config.py
@@ -62,6 +62,8 @@ class Config(object):
     EMAIL_PORT = os.getenv("EMAIL_PORT")
     RECIPIENT_EMAIL = os.getenv("RECIPIENT_EMAIL")
     DISABLE_MAILER = os.getenv("DISABLE_MAILER") == "YES"
+    BATCH_SIZE = os.getenv("BATCH_SIZE") or 500
+    PAGE_SIZE = os.getenv("PAGE_SIZE") or 500
 
 
 class TestConfig(Config):
@@ -80,6 +82,8 @@ class TestConfig(Config):
     SCHOOL_YEAR_START = "2020-01-01"
     SQLITE_FILE = "tests.db"
     STUDENT_ORG_UNIT = "Test Organization 2"
+    BATCH_SIZE = 500
+    PAGE_SIZE = 500
 
 
 def db_generator(config):

--- a/config.py
+++ b/config.py
@@ -62,8 +62,17 @@ class Config(object):
     EMAIL_PORT = os.getenv("EMAIL_PORT")
     RECIPIENT_EMAIL = os.getenv("RECIPIENT_EMAIL")
     DISABLE_MAILER = os.getenv("DISABLE_MAILER") == "YES"
-    BATCH_SIZE = os.getenv("BATCH_SIZE") or 500
-    PAGE_SIZE = os.getenv("PAGE_SIZE") or 500
+    ORG_UNIT_BATCH_SIZE = int(os.getenv("ORG_UNIT_BATCH_SIZE") or 1000)
+    USAGE_BATCH_SIZE = int(os.getenv("USAGE_BATCH_SIZE") or 1000)
+    COURSES_BATCH_SIZE = int(os.getenv("COURSES_BATCH_SIZE") or 1000)
+    TOPICS_BATCH_SIZE = int(os.getenv("TOPICS_BATCH_SIZE") or 1000)
+    COURSEWORK_BATCH_SIZE = int(os.getenv("COURSEWORK_BATCH_SIZE") or 120)
+    STUDENTS_BATCH_SIZE = int(os.getenv("STUDENTS_BATCH_SIZE") or 1000)
+    TEACHERS_BATCH_SIZE = int(os.getenv("TEACHERS_BATCH_SIZE") or 1000)
+    GUARDIANS_BATCH_SIZE = int(os.getenv("GUARDIANS_BATCH_SIZE") or 1000)
+    SUBMISSIONS_BATCH_SIZE = int(os.getenv("SUBMISSIONS_BATCH_SIZE") or 120)
+    GUARDIAN_INVITES_BATCH_SIZE = int(os.getenv("GUARDIAN_INVITES_BATCH_SIZE") or 1000)
+    PAGE_SIZE = int(os.getenv("PAGE_SIZE") or 1000)
 
 
 class TestConfig(Config):
@@ -82,8 +91,17 @@ class TestConfig(Config):
     SCHOOL_YEAR_START = "2020-01-01"
     SQLITE_FILE = "tests.db"
     STUDENT_ORG_UNIT = "Test Organization 2"
-    BATCH_SIZE = 500
-    PAGE_SIZE = 500
+    ORG_UNIT_BATCH_SIZE = 1000
+    USAGE_BATCH_SIZE = 1000
+    COURSES_BATCH_SIZE = 1000
+    TOPICS_BATCH_SIZE = 1000
+    COURSEWORK_BATCH_SIZE = 120
+    STUDENTS_BATCH_SIZE = 1000
+    TEACHERS_BATCH_SIZE = 1000
+    GUARDIANS_BATCH_SIZE = 1000
+    SUBMISSIONS_BATCH_SIZE = 120
+    GUARDIAN_INVITES_BATCH_SIZE = 1000
+    PAGE_SIZE = 1000
 
 
 def db_generator(config):

--- a/main.py
+++ b/main.py
@@ -89,7 +89,7 @@ def main(config):
         # First get student org unit
         result = OrgUnits(
             admin_directory_service, config.STUDENT_ORG_UNIT
-        ).get_and_write_to_db(sql, debug=config.DEBUG)
+        ).batch_pull_data(sql, debug=config.DEBUG)
         ou_id = None if result.empty else result.iloc[0]
 
         # Then get usage
@@ -105,21 +105,21 @@ def main(config):
         date_range = pd.date_range(start=start_date, end=datetime.today()).strftime(
             "%Y-%m-%d"
         )
-        usage.get_and_write_to_db(
+        usage.batch_pull_data(
             sql, dates=date_range, overwrite=False, debug=config.DEBUG
         )
 
     # Get guardians
     if config.PULL_GUARDIANS:
-        Guardians(classroom_service).get_and_write_to_db(sql, debug=config.DEBUG)
+        Guardians(classroom_service).batch_pull_data(sql, debug=config.DEBUG)
 
     # Get guardian invites
     if config.PULL_GUARDIAN_INVITES:
-        GuardianInvites(classroom_service).get_and_write_to_db(sql, debug=config.DEBUG)
+        GuardianInvites(classroom_service).batch_pull_data(sql, debug=config.DEBUG)
 
     # Get courses
     if config.PULL_COURSES:
-        Courses(classroom_service, config.SCHOOL_YEAR_START).get_and_write_to_db(
+        Courses(classroom_service, config.SCHOOL_YEAR_START).batch_pull_data(
             sql, debug=config.DEBUG
         )
 
@@ -137,31 +137,25 @@ def main(config):
 
     # Get course topics
     if config.PULL_TOPICS:
-        Topics(classroom_service).get_and_write_to_db(
-            sql, course_ids, debug=config.DEBUG
-        )
+        Topics(classroom_service).batch_pull_data(sql, course_ids, debug=config.DEBUG)
 
     # Get CourseWork
     if config.PULL_COURSEWORK:
-        CourseWork(classroom_service).get_and_write_to_db(
+        CourseWork(classroom_service).batch_pull_data(
             sql, course_ids, debug=config.DEBUG
         )
 
     # Get students and insert into database
     if config.PULL_STUDENTS:
-        Students(classroom_service).get_and_write_to_db(
-            sql, course_ids, debug=config.DEBUG
-        )
+        Students(classroom_service).batch_pull_data(sql, course_ids, debug=config.DEBUG)
 
     # Get teachers and insert into database
     if config.PULL_TEACHERS:
-        Teachers(classroom_service).get_and_write_to_db(
-            sql, course_ids, debug=config.DEBUG
-        )
+        Teachers(classroom_service).batch_pull_data(sql, course_ids, debug=config.DEBUG)
 
     # Get student coursework submissions
     if config.PULL_SUBMISSIONS:
-        StudentSubmissions(classroom_service).get_and_write_to_db(
+        StudentSubmissions(classroom_service).batch_pull_data(
             sql, course_ids, debug=config.DEBUG
         )
 

--- a/main.py
+++ b/main.py
@@ -87,41 +87,35 @@ def main(config):
     # Get usage
     if config.PULL_USAGE:
         # First get student org unit
-        result = OrgUnits(
-            admin_directory_service, config.STUDENT_ORG_UNIT
-        ).batch_pull_data(sql, debug=config.DEBUG)
+        result = OrgUnits(admin_directory_service, sql, config).batch_pull_data()
         ou_id = None if result.empty else result.iloc[0]
 
         # Then get usage
         # Clear out the last day's worth of data, because it may only be partially
         # complete. Then load data on all dates from that day until today.
-        usage = StudentUsage(admin_reports_service, ou_id)
-        last_date = usage.get_last_date(sql)
+        usage = StudentUsage(admin_reports_service, sql, config, ou_id)
+        last_date = usage.get_last_date()
         if last_date:
-            usage.remove_dates_after(sql, last_date)
+            usage.remove_dates_after(last_date)
         start_date = last_date or datetime.strptime(
             config.SCHOOL_YEAR_START, "%Y-%m-%d"
         )
         date_range = pd.date_range(start=start_date, end=datetime.today()).strftime(
             "%Y-%m-%d"
         )
-        usage.batch_pull_data(
-            sql, dates=date_range, overwrite=False, debug=config.DEBUG
-        )
+        usage.batch_pull_data(dates=date_range, overwrite=False)
 
     # Get guardians
     if config.PULL_GUARDIANS:
-        Guardians(classroom_service).batch_pull_data(sql, debug=config.DEBUG)
+        Guardians(classroom_service, sql, config).batch_pull_data()
 
     # Get guardian invites
     if config.PULL_GUARDIAN_INVITES:
-        GuardianInvites(classroom_service).batch_pull_data(sql, debug=config.DEBUG)
+        GuardianInvites(classroom_service, sql, config).batch_pull_data()
 
     # Get courses
     if config.PULL_COURSES:
-        Courses(classroom_service, config.SCHOOL_YEAR_START).batch_pull_data(
-            sql, debug=config.DEBUG
-        )
+        Courses(classroom_service, sql, config).batch_pull_data()
 
     # Get list of course ids
     if (
@@ -131,33 +125,27 @@ def main(config):
         or config.PULL_TEACHERS
         or config.PULL_SUBMISSIONS
     ):
-        course_ids = Courses(
-            classroom_service, config.SCHOOL_YEAR_START
-        ).get_course_ids(sql)
+        course_ids = Courses(classroom_service, sql, config).get_course_ids()
 
     # Get course topics
     if config.PULL_TOPICS:
-        Topics(classroom_service).batch_pull_data(sql, course_ids, debug=config.DEBUG)
+        Topics(classroom_service, sql, config).batch_pull_data(course_ids)
 
     # Get CourseWork
     if config.PULL_COURSEWORK:
-        CourseWork(classroom_service).batch_pull_data(
-            sql, course_ids, debug=config.DEBUG
-        )
+        CourseWork(classroom_service, sql, config).batch_pull_data(course_ids)
 
     # Get students and insert into database
     if config.PULL_STUDENTS:
-        Students(classroom_service).batch_pull_data(sql, course_ids, debug=config.DEBUG)
+        Students(classroom_service, sql, config).batch_pull_data(course_ids)
 
     # Get teachers and insert into database
     if config.PULL_TEACHERS:
-        Teachers(classroom_service).batch_pull_data(sql, course_ids, debug=config.DEBUG)
+        Teachers(classroom_service, sql, config).batch_pull_data(course_ids)
 
     # Get student coursework submissions
     if config.PULL_SUBMISSIONS:
-        StudentSubmissions(classroom_service).batch_pull_data(
-            sql, course_ids, debug=config.DEBUG
-        )
+        StudentSubmissions(classroom_service, sql, config).batch_pull_data(course_ids)
 
 
 if __name__ == "__main__":

--- a/test_responses.py
+++ b/test_responses.py
@@ -286,6 +286,20 @@ TEACHER_RESPONSE = {
 }
 
 
+class FakeBatchRequest:
+    def __init__(self, callback):
+        self.callback = callback
+        self.requests = []
+
+    def add(self, request, request_id):
+        self.requests.append((request, request_id))
+
+    def execute(self):
+        for (request, request_id) in self.requests:
+            result = request.execute()
+            self.callback(request_id, result, None)
+
+
 class FakeRequest:
     def __init__(self, result, *args, **kwargs):
         self.result = result
@@ -329,6 +343,9 @@ class FakeService:
 
     def orgunits(self):
         return FakeEndpoint(ORG_UNIT_RESPONSE)
+
+    def new_batch_http_request(self, callback):
+        return FakeBatchRequest(callback)
 
     class UserProfiles:
         def guardians(self):

--- a/tests.py
+++ b/tests.py
@@ -66,7 +66,7 @@ class TestEndToEnd:
         )
 
     def generic_get_test(self, endpoint, solution, course_ids=[None]):
-        endpoint.get_and_write_to_db(
+        endpoint.batch_pull_data(
             self.sql, debug=self.config.DEBUG, course_ids=course_ids
         )
         result = pd.read_sql_table(

--- a/tests.py
+++ b/tests.py
@@ -36,39 +36,48 @@ class TestEndToEnd:
 
     def test_get_org_units(self):
         self.generic_get_test(
-            OrgUnits(self.service, self.config.STUDENT_ORG_UNIT), ORG_UNIT_SOLUTION,
+            OrgUnits(self.service, self.sql, self.config), ORG_UNIT_SOLUTION,
         )
 
     def test_get_guardians(self):
-        self.generic_get_test(Guardians(self.service), GUARDIAN_SOLUTION)
+        self.generic_get_test(
+            Guardians(self.service, self.sql, self.config), GUARDIAN_SOLUTION
+        )
 
     def test_get_guardian_invites(self):
-        self.generic_get_test(GuardianInvites(self.service), GUARDIAN_INVITE_SOLUTION)
+        self.generic_get_test(
+            GuardianInvites(self.service, self.sql, self.config),
+            GUARDIAN_INVITE_SOLUTION,
+        )
 
     def test_get_courses(self):
         self.generic_get_test(
-            Courses(self.service, self.config.SCHOOL_YEAR_START), COURSE_SOLUTION,
+            Courses(self.service, self.sql, self.config), COURSE_SOLUTION,
         )
 
     def test_get_topics(self):
         self.generic_get_test(
-            Topics(self.service), TOPIC_SOLUTION, course_ids=[0, 1],
+            Topics(self.service, self.sql, self.config),
+            TOPIC_SOLUTION,
+            course_ids=[0, 1],
         )
 
     def test_get_students(self):
         self.generic_get_test(
-            Students(self.service), STUDENT_SOLUTION, course_ids=[0, 1],
+            Students(self.service, self.sql, self.config),
+            STUDENT_SOLUTION,
+            course_ids=[0, 1],
         )
 
     def test_get_teachers(self):
         self.generic_get_test(
-            Teachers(self.service), TEACHER_SOLUTION, course_ids=[0, 1],
+            Teachers(self.service, self.sql, self.config),
+            TEACHER_SOLUTION,
+            course_ids=[0, 1],
         )
 
     def generic_get_test(self, endpoint, solution, course_ids=[None]):
-        endpoint.batch_pull_data(
-            self.sql, debug=self.config.DEBUG, course_ids=course_ids
-        )
+        endpoint.batch_pull_data(course_ids=course_ids)
         result = pd.read_sql_table(
             endpoint.table_name, con=self.sql.engine, schema=self.sql.schema
         )


### PR DESCRIPTION
Depends on #35 
Fixes #17

Test Plan: All local tests pass, manually verified that a run of main.py produces seemingly correct data into the DB.

This diff adds batch calling. It's a fairly substantial rewrite of the API, but the component changes are:
 - Pushing params into the `request_data()` function so that they are more stateless and can be queued in a batch request.
 - Pushing sql and config params into the initialize function so it is easily accessible everywhere and doesn't need to be passed as a param so much.
 - Accumulating all of the batch requests and sending them off all at once to a batch object.
 - Grouping those batches and adding params for batch size (by query) and page size, with defaults based on our own optimization.
 - Handling those batches as they come in through the callback.
 - Add a fake batch object for testing purposes.
 - Cleaning up logging so that it is not as noisy when it is not in debug mode.

A few notes on implementation:
 - The callback is a nested method per the patterns seen in Google documentation.
 - The `batch.execute()` hangs until all of the callbacks have completed, so that gives the response time to add more calls to the queue in cases where there is another page. This is why the while loop works.

@dchess This should be tested on production before we consider merging so that we understand whether it solves some of our performance issues. Once this is ready, please let me know the before/after on a full run.