### PR TITLE
Ignore partial data in usage report

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import datetime, timedelta
 import logging
 import os
 import pickle
@@ -72,14 +72,10 @@ def main(config):
         result = OrgUnits(admin_directory_service, sql, config).batch_pull_data()
         org_unit_id = None if result.empty else result.iloc[0].loc["orgUnitId"]
 
-        # Then get usage
-        # Clear out the last day's worth of data, because it may only be partially
-        # complete. Then load data on all dates from that day until today.
+        # Then get usage, loading data from after the last available day.
         usage = StudentUsage(admin_reports_service, sql, config, org_unit_id)
         last_date = usage.get_last_date()
-        if last_date:
-            usage.remove_dates_after(last_date)
-        start_date = last_date or datetime.strptime(
+        start_date = last_date + timedelta(days=1) or datetime.strptime(
             config.SCHOOL_YEAR_START, "%Y-%m-%d"
         )
         date_range = pd.date_range(start=start_date, end=datetime.today()).strftime(


### PR DESCRIPTION
Fixes #41

Instead of deleting the last day of data and rerunning it, this now detects partial data issues and doesn't load them at all. This is because there can actually be multiple days of partial data.

Also added a parameter filter to the usage report, which dramatically speeds up the request.

Note that it only does this if the partial data warning is for Google classroom — there are times where the partial data is only for other applications, and that is ok.

For testing / migration, make sure to manually delete any days with partial data first.