### PR TITLE
Add a flag for pulling all data

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,7 @@ pipenv run python main.py
 
 Optional flags will include different types of pulls (can also be done via env variables):
 
+- `--all` (for pulling all data)
 - `--usage`
 - `--courses`
 - `--topics`

--- a/config.py
+++ b/config.py
@@ -7,6 +7,7 @@ from sqlsorcery import MSSQL, PostgreSQL, SQLite
 
 def get_args():
     parser = argparse.ArgumentParser(description="Pick which ones")
+    parser.add_argument("--all", help="Import all data", action="store_true")
     parser.add_argument(
         "--usage", help="Import student usage data", action="store_true"
     )
@@ -48,15 +49,21 @@ class Config(object):
     SCHOOL_YEAR_START = os.getenv("SCHOOL_YEAR_START")
     DB_TYPE = os.getenv("DB_TYPE")
     DEBUG = args.debug
-    PULL_USAGE = os.getenv("PULL_USAGE") == "YES" or args.usage
-    PULL_COURSES = os.getenv("PULL_COURSES") == "YES" or args.courses
-    PULL_TOPICS = os.getenv("PULL_TOPICS") == "YES" or args.topics
-    PULL_COURSEWORK = os.getenv("PULL_COURSEWORK") == "YES" or args.coursework
-    PULL_STUDENTS = os.getenv("PULL_STUDENTS") == "YES" or args.students
-    PULL_TEACHERS = os.getenv("PULL_TEACHERS") == "YES" or args.teachers
-    PULL_GUARDIANS = os.getenv("PULL_GUARDIANS") == "YES" or args.guardians
-    PULL_SUBMISSIONS = os.getenv("PULL_SUBMISSIONS") == "YES" or args.submissions
-    PULL_GUARDIAN_INVITES = os.getenv("PULL_GUARDIAN_INVITES") == "YES" or args.invites
+    PULL_USAGE = os.getenv("PULL_USAGE") == "YES" or args.usage or args.all
+    PULL_COURSES = os.getenv("PULL_COURSES") == "YES" or args.courses or args.all
+    PULL_TOPICS = os.getenv("PULL_TOPICS") == "YES" or args.topics or args.all
+    PULL_COURSEWORK = (
+        os.getenv("PULL_COURSEWORK") == "YES" or args.coursework or args.all
+    )
+    PULL_STUDENTS = os.getenv("PULL_STUDENTS") == "YES" or args.students or args.all
+    PULL_TEACHERS = os.getenv("PULL_TEACHERS") == "YES" or args.teachers or args.all
+    PULL_GUARDIANS = os.getenv("PULL_GUARDIANS") == "YES" or args.guardians or args.all
+    PULL_SUBMISSIONS = (
+        os.getenv("PULL_SUBMISSIONS") == "YES" or args.submissions or args.all
+    )
+    PULL_GUARDIAN_INVITES = (
+        os.getenv("PULL_GUARDIAN_INVITES") == "YES" or args.invites or args.all
+    )
     SENDER_EMAIL = os.getenv("SENDER_EMAIL")
     SENDER_PWD = os.getenv("SENDER_PWD")
     EMAIL_SERVER = os.getenv("EMAIL_SERVER")


### PR DESCRIPTION
Fixes #42 

Adds a `--all` flag for easily calling all of the endpoints. There's a lot more complexity to detecting if none of the flags have been used, so it is worth talking over the approach there if we want to go down that path(do we do it just for args or for the .env file, and is it more clear to have an opt-out rather than opt-in if we do that).