### PR TITLE
Fix Pandas -> DB Type Error in Coursework

### DIFF
--- a/api.py
+++ b/api.py
@@ -54,6 +54,7 @@ class EndPoint:
         df = pd.json_normalize(new_records)
         df = df.reindex(columns=self.columns)
         df = self.filter_data(df)
+        df = df.astype("object")
         if self.date_columns:
             date_types = {col: "datetime64[ns]" for col in self.date_columns}
             df = df.astype(date_types)


### PR DESCRIPTION
This fixes an error where an empty description causes the pandas `reindex` function to create a `float64` column for description, which then errors when a string is added to it. Instead, it just converts all columns to the `object` type (before later converting relevant points to the date type). The object dtype is capable of handling ints, floats, and strings.

This is something of a temporary fix, as the long-term solution if data types matter is to enumerate exactly which data type each column should be.