### PR TITLE
Improve performance by moving logic out of callback

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,6 +160,7 @@ Optional flags will include different types of pulls (can also be done via env v
 - `--announcements`
 
 Use the flag `--debug` to turn on debug logging.
+Use the flag `--debugfile` to save raw json to a file for backup / auditing.
 
 ### Running Tests
 

--- a/api.py
+++ b/api.py
@@ -77,7 +77,7 @@ class EndPoint:
         logging.debug(
             f"{self.classname()}: inserting {len(df)} records into {self.table_name}."
         )
-        self.sql.insert_into(self.table_name, df)
+        self.sql.insert_into(self.table_name, df, chunksize=10000)
 
     def _delete_local_file(self):
         """Deletes the local debug json file in /data."""

--- a/config.py
+++ b/config.py
@@ -43,6 +43,9 @@ def get_args():
     parser.add_argument(
         "--debug", help="Set logging level for troubleshooting", action="store_true"
     )
+    parser.add_argument(
+        "--debugfile", help="Log raw json to a file", action="store_true"
+    )
     args, _ = parser.parse_known_args()
     return args
 
@@ -56,6 +59,7 @@ class Config(object):
     SCHOOL_YEAR_START = os.getenv("SCHOOL_YEAR_START")
     DB_TYPE = os.getenv("DB_TYPE")
     DEBUG = args.debug
+    DEBUGFILE = args.debugfile
     PULL_USAGE = os.getenv("PULL_USAGE") == "YES" or args.usage or args.all
     PULL_COURSES = os.getenv("PULL_COURSES") == "YES" or args.courses or args.all
     PULL_TOPICS = os.getenv("PULL_TOPICS") == "YES" or args.topics or args.all
@@ -103,6 +107,7 @@ class Config(object):
 class TestConfig(Config):
     DB_TYPE = "sqlite"
     DEBUG = False
+    DEBUGFILE = False
     PULL_USAGE = True
     PULL_COURSES = True
     PULL_TOPICS = True

--- a/main.py
+++ b/main.py
@@ -73,7 +73,9 @@ def main(config):
     # Get usage
     if config.PULL_USAGE:
         # First get student org unit
-        result = OrgUnits(admin_directory_service, sql, config).batch_pull_data()
+        orgUnits = OrgUnits(admin_directory_service, sql, config)
+        orgUnits.batch_pull_data()
+        result = orgUnits.return_all_data()
         org_unit_id = None if result.empty else result.iloc[0].loc["orgUnitId"]
 
         # Then get usage, loading data from after the last available day.

--- a/main.py
+++ b/main.py
@@ -113,7 +113,8 @@ def main(config):
         or config.PULL_INVITATIONS
         or config.PULL_ANNOUNCEMENTS
     ):
-        course_ids = Courses(classroom_service, sql, config).get_course_ids()
+        courses = Courses(classroom_service, sql, config).return_all_data()
+        course_ids = courses.id.unique()
 
     # Get course aliases
     if config.PULL_ALIASES:

--- a/test_responses.py
+++ b/test_responses.py
@@ -397,7 +397,7 @@ class FakeRequest:
                 # If a course_id is provided, this splits the results into two courses.
                 key = list(self.result.keys())[0]
                 if course_id == 0:
-                    return {key: self.result[key][0]}
+                    return {key: self.result[key][:1]}
                 else:
                     return {key: self.result[key][1:]}
         return self.result


### PR DESCRIPTION
Fixes #64

Improves performance by moving as much logic as possible out of the callback and into the batching, including record processing and file/DB writes. With the longest endpoint (Student Submissions), this improved performance from 31 minutes to 9 minutes.

With this change, further optimization of batch size may also increase performance. In one test, I increased batch size to 300 and was able to run at 8.5 minutes.