### PR TITLE
Fix Bug Caused By Empty Usage Table

### DIFF
--- a/main.py
+++ b/main.py
@@ -75,9 +75,10 @@ def main(config):
         # Then get usage, loading data from after the last available day.
         usage = StudentUsage(admin_reports_service, sql, config, org_unit_id)
         last_date = usage.get_last_date()
-        start_date = last_date + timedelta(days=1) or datetime.strptime(
-            config.SCHOOL_YEAR_START, "%Y-%m-%d"
-        )
+        if last_date:
+            start_date = last_date + timedelta(days=1)
+        else:
+            start_date = datetime.strptime(config.SCHOOL_YEAR_START, "%Y-%m-%d")
         date_range = pd.date_range(start=start_date, end=datetime.today()).strftime(
             "%Y-%m-%d"
         )


### PR DESCRIPTION
Fixes #68 

Fixes a bug where having an empty usage table led to a TypeError trying to add a timedelta to a null date. This checks for the null date first.