### PR TITLE
Adds Course ID to Aliases

### DIFF
--- a/google_classroom/api.py
+++ b/google_classroom/api.py
@@ -38,6 +38,8 @@ class EndPoint:
         self.date_columns = []
         self.request_key = None
         self.table_name = f"GoogleClassroom_{self.classname()}"
+        # Set to True in a subclass if the API response doesn't include course IDs.
+        self.inject_course_id = False
 
     def return_all_data(self):
         """Returns all the data in the associated table"""
@@ -224,6 +226,11 @@ class EndPoint:
             logging_string += f", page {page}" if page else ""
             logging_string += "."
             logging.debug(logging_string)
+
+            if self.inject_course_id:
+                for record in records:
+                    record["courseId"] = course_id
+
             nonlocal batch_data
             batch_data.extend(records)
 
@@ -651,6 +658,7 @@ class CourseAliases(EndPoint):
         self.columns = ["courseId", "alias"]
         self.request_key = "aliases"
         self.batch_size = config.ALIASES_BATCH_SIZE
+        self.inject_course_id = True
 
     def request_data(self, course_id=None, date=None, next_page_token=None):
         return (

--- a/tests/mock_response.py
+++ b/tests/mock_response.py
@@ -40,12 +40,16 @@ class FakeRequest:
         if "courseId" in self.kwargs:
             course_id = self.kwargs["courseId"]
             if course_id is not None:
-                # If a course_id is provided, this splits the results into two courses.
+                # Split responses by the course_id.
                 key = list(self.result.keys())[0]
-                if course_id == 0:
-                    return {key: self.result[key][:1]}
+                values = self.result[key]
+                # Aliases are an exception because the response doesn't contain the
+                # course ID, so they have to be split manually.
+                if key == "aliases":
+                    matches = values[:1] if course_id == "1" else values[1:]
                 else:
-                    return {key: self.result[key][1:]}
+                    matches = [item for item in values if item["courseId"] == course_id]
+                return {key: matches}
         if "date" in self.kwargs:
             date = self.kwargs["date"]
             return self.result.get(date)

--- a/tests/responses.py
+++ b/tests/responses.py
@@ -165,28 +165,30 @@ COURSE_RESPONSE = {
     ]
 }
 
-ALIAS_SOLUTION = pd.DataFrame({"courseId": [None], "alias": ["d:school_test1"]})
-ALIAS_RESPONSE = {"aliases": [{"alias": "d:school_test1"}]}
+ALIAS_SOLUTION = pd.DataFrame(
+    {"courseId": ["1", "2"], "alias": ["d:school_test1", "d:school_test2"]}
+)
+ALIAS_RESPONSE = {"aliases": [{"alias": "d:school_test1"}, {"alias": "d:school_test2"}]}
 
 INVITATION_SOLUTION = pd.DataFrame(
     {
         "id": ["12345", "23456"],
         "userId": ["1", "2"],
-        "courseId": ["1234", "5678"],
+        "courseId": ["1", "2"],
         "role": ["STUDENT", "STUDENT"],
     }
 )
 INVITATION_RESPONSE = {
     "invitations": [
-        {"id": "12345", "userId": "1", "courseId": "1234", "role": "STUDENT"},
-        {"id": "23456", "userId": "2", "courseId": "5678", "role": "STUDENT"},
+        {"id": "12345", "userId": "1", "courseId": "1", "role": "STUDENT"},
+        {"id": "23456", "userId": "2", "courseId": "2", "role": "STUDENT"},
     ]
 }
 
 ANNOUNCEMENT_SOLUTION = pd.DataFrame(
     {
         "id": ["12345", "23456"],
-        "courseId": ["1234", "5678"],
+        "courseId": ["1", "2"],
         "text": ["Test Announcement #1", "Test Announcement #2"],
         "state": ["PUBLISHED", "PUBLISHED"],
         "alternateLink": [
@@ -212,7 +214,7 @@ ANNOUNCEMENT_SOLUTION = pd.DataFrame(
 ANNOUNCEMENT_RESPONSE = {
     "announcements": [
         {
-            "courseId": "1234",
+            "courseId": "1",
             "id": "12345",
             "text": "Test Announcement #1",
             "materials": [],
@@ -226,7 +228,7 @@ ANNOUNCEMENT_RESPONSE = {
             "creatorUserId": "555",
         },
         {
-            "courseId": "5678",
+            "courseId": "2",
             "id": "23456",
             "text": "Test Announcement #2",
             "materials": [],
@@ -244,7 +246,7 @@ ANNOUNCEMENT_RESPONSE = {
 
 TOPIC_SOLUTION = pd.DataFrame(
     {
-        "courseId": ["1234", "5678"],
+        "courseId": ["1", "2"],
         "topicId": ["1235", "1234"],
         "name": ["Chemistry", "Biology"],
         "updateTime": [
@@ -256,13 +258,13 @@ TOPIC_SOLUTION = pd.DataFrame(
 TOPIC_RESPONSE = {
     "topic": [
         {
-            "courseId": "1234",
+            "courseId": "1",
             "topicId": "1235",
             "name": "Chemistry",
             "updateTime": "2020-04-05T22:41:55.87Z",
         },
         {
-            "courseId": "5678",
+            "courseId": "2",
             "topicId": "1234",
             "name": "Biology",
             "updateTime": "2020-04-05T22:41:49.18Z",
@@ -272,7 +274,7 @@ TOPIC_RESPONSE = {
 
 STUDENT_SOLUTION = pd.DataFrame(
     {
-        "courseId": ["123", "123"],
+        "courseId": ["1", "2"],
         "userId": ["1", "2"],
         "fullName": ["Test User", "Another User"],
         "emailAddress": ["test_user@email.com", "another_user@email.com"],
@@ -281,7 +283,7 @@ STUDENT_SOLUTION = pd.DataFrame(
 STUDENT_RESPONSE = {
     "students": [
         {
-            "courseId": "123",
+            "courseId": "1",
             "userId": "1",
             "profile": {
                 "id": "222",
@@ -294,7 +296,7 @@ STUDENT_RESPONSE = {
             },
         },
         {
-            "courseId": "123",
+            "courseId": "2",
             "userId": "2",
             "profile": {
                 "id": "333",
@@ -312,7 +314,7 @@ STUDENT_RESPONSE = {
 
 TEACHER_SOLUTION = pd.DataFrame(
     {
-        "courseId": ["111", "333", "444"],
+        "courseId": ["1", "2", "2"],
         "userId": ["555", "321", "555"],
         "fullName": ["Boss Lady", "Mr. Teacher", "Mrs. Teacher"],
         "emailAddress": [
@@ -325,7 +327,7 @@ TEACHER_SOLUTION = pd.DataFrame(
 TEACHER_RESPONSE = {
     "teachers": [
         {
-            "courseId": "111",
+            "courseId": "1",
             "userId": "555",
             "profile": {
                 "id": "987",
@@ -339,7 +341,7 @@ TEACHER_RESPONSE = {
             },
         },
         {
-            "courseId": "333",
+            "courseId": "2",
             "userId": "321",
             "profile": {
                 "id": "543",
@@ -353,7 +355,7 @@ TEACHER_RESPONSE = {
             },
         },
         {
-            "courseId": "444",
+            "courseId": "2",
             "userId": "555",
             "profile": {
                 "id": "789",

--- a/tests/test_all.py
+++ b/tests/test_all.py
@@ -85,56 +85,56 @@ class TestEndToEnd:
         self.generic_get_test(
             Topics(self.service, self.sql, self.config),
             TOPIC_SOLUTION,
-            course_ids=[0, 1],
+            course_ids=["1", "2"],
         )
 
     def test_get_students(self):
         self.generic_get_test(
             Students(self.service, self.sql, self.config),
             STUDENT_SOLUTION,
-            course_ids=[0, 1],
+            course_ids=["1", "2"],
         )
 
     def test_get_teachers(self):
         self.generic_get_test(
             Teachers(self.service, self.sql, self.config),
             TEACHER_SOLUTION,
-            course_ids=[0, 1],
+            course_ids=["1", "2"],
         )
 
     def test_get_aliases(self):
         self.generic_get_test(
             CourseAliases(self.service, self.sql, self.config),
             ALIAS_SOLUTION,
-            course_ids=[0, 1],
+            course_ids=["1", "2"],
         )
 
     def test_get_invitations(self):
         self.generic_get_test(
             Invitations(self.service, self.sql, self.config),
             INVITATION_SOLUTION,
-            course_ids=[0, 1],
+            course_ids=["1", "2"],
         )
 
     def test_get_announcements(self):
         self.generic_get_test(
             Announcements(self.service, self.sql, self.config),
             ANNOUNCEMENT_SOLUTION,
-            course_ids=[0, 1],
+            course_ids=["1", "2"],
         )
 
     def test_get_submissions(self):
         self.generic_get_test(
             StudentSubmissions(self.service, self.sql, self.config),
             STUDENT_SUBMISSION_SOLUTION,
-            course_ids=[0, 1],
+            course_ids=["1", "2"],
         )
 
     def test_get_coursework(self):
         self.generic_get_test(
             CourseWork(self.service, self.sql, self.config),
             COURSEWORK_SOLUTION,
-            course_ids=[0, 1],
+            course_ids=["1", "2"],
         )
 
     def generic_get_test(self, endpoint, solution, course_ids=[None], dates=[None]):


### PR DESCRIPTION
Fixes #92 
Depends on #84 

Adds a course ID to Aliases, as well as any other future endpoint that might need it.

This also replaces a hacky implementation of execution by course ID in the testing object so that it actually filters the response object by the course ID in the response. It is not used in the case of aliases because the response doesn't contain course IDs, but it was called to attention when I added the API code and discovered the course IDs weren't matching up between request and solution.