### PR TITLE
Course states

### DIFF
--- a/google_classroom/api.py
+++ b/google_classroom/api.py
@@ -407,7 +407,6 @@ class Courses(EndPoint):
     def request_data(self, course_id=None, date=None, next_page_token=None):
         return self.service.courses().list(
             pageToken=next_page_token,
-            courseStates=["ACTIVE"],
             pageSize=self.config.PAGE_SIZE,
         )
 

--- a/google_classroom/api.py
+++ b/google_classroom/api.py
@@ -406,8 +406,7 @@ class Courses(EndPoint):
 
     def request_data(self, course_id=None, date=None, next_page_token=None):
         return self.service.courses().list(
-            pageToken=next_page_token,
-            pageSize=self.config.PAGE_SIZE,
+            pageToken=next_page_token, pageSize=self.config.PAGE_SIZE,
         )
 
     def filter_data(self, dataframe):

--- a/google_classroom/main.py
+++ b/google_classroom/main.py
@@ -113,6 +113,7 @@ def main(config):
         or config.PULL_ANNOUNCEMENTS
     ):
         courses = Courses(classroom_service, sql, config).return_all_data()
+        courses = courses[courses["courseState"] == "ACTIVE"]
         course_ids = courses.id.unique()
 
     # Get course invitations


### PR DESCRIPTION
Fixes #95 

Removes request param filtering on ACTIVE courseState and adds query filter to course_ids for ACTIVE courses. This way we have a record of which courses are archived but are not making requests to the coursework, submissions, etc endpoints for non-active courses.  