### PR TITLE
Remove second run of Invitation

### DIFF
--- a/google_classroom/endpoints/course.py
+++ b/google_classroom/endpoints/course.py
@@ -26,7 +26,8 @@ class Courses(EndPoint):
 
     def request_data(self, course_id=None, date=None, next_page_token=None):
         return self.service.courses().list(
-            pageToken=next_page_token, pageSize=self.config.PAGE_SIZE,
+            pageToken=next_page_token,
+            pageSize=self.config.PAGE_SIZE,
         )
 
     def filter_data(self, dataframe):

--- a/google_classroom/main.py
+++ b/google_classroom/main.py
@@ -117,6 +117,7 @@ def pull_data(config, creds, sql):
         or config.PULL_ALIASES
         or config.PULL_INVITATIONS
         or config.PULL_ANNOUNCEMENTS
+        or config.PULL_MEET
     ):
         courses = Courses(classroom_service, sql, config).return_all_data()
         courses = courses[courses["courseState"] == "ACTIVE"]
@@ -133,10 +134,6 @@ def pull_data(config, creds, sql):
     # Get course aliases
     if config.PULL_ALIASES:
         CourseAliases(classroom_service, sql, config).batch_pull_data(course_ids)
-
-    # Get course invitations
-    if config.PULL_INVITATIONS:
-        Invitations(classroom_service, sql, config).batch_pull_data(course_ids)
 
     # Get course topics
     if config.PULL_TOPICS:


### PR DESCRIPTION
Fixes a bug where the Invitation pull would run twice.

Also fixes a bug where only turning on PULL_MEET wouldn't get the list of courses.