### PR TITLE
Ensure Github Action check properly fails when the tests fail

### DIFF
--- a/run_tests.sh
+++ b/run_tests.sh
@@ -1,4 +1,6 @@
 #!/bin/bash
 
 docker-compose -f docker-compose.test.yml up --build --abort-on-container-exit --exit-code-from app
+TEST_RESULT=$?
 docker-compose -f docker-compose.test.yml down --volumes
+exit $TEST_RESULT


### PR DESCRIPTION
Fixes #106 
Fixes an issue where the Github Action was not properly failing when tests failed. This propagates the test failure to the action itself.

Note that the result has to be stored after the first docker-compose call, because otherwise $? will be overwritten by the results of the second call (which should always be successful).